### PR TITLE
Add custom database path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently works with WVW and Detailed WVW logs. Partially working with PVElogs, 
      - Ensure you have `Output as JSON` checked on the Raw output tab
      - There is a provided example EI settings config file you can load via the `load settings` button in the `/EliteInsightConfig` folder
  - Decompress the [latest release](https://github.com/Drevarr/GW2_EI_log_combiner/releases) file to your preferred location
- - Edit the `top_stats_config.ini` file to set the `input_directory` so it points to the location of your saved JSON logs
+ - Edit the `top_stats_config.ini` file to set the `input_directory` so it points to the location of your saved JSON logs. Optional fields `db_output_filename` and `db_path` control the name and location of the SQLite database.
  - Double click the `TopStats.exe` to run
  - Open the file `/Example_Output/Top_Stats_Index.html` in your browser of choice.
  - Drag and Drop the file `Drag_and_Drop_Log_Summary_for_2024yourdatatime.json` onto the opened `Top_Stats_Index.html` in your browser and click `import`

--- a/output_functions.py
+++ b/output_functions.py
@@ -3997,7 +3997,7 @@ def build_pull_stats_tid(tid_date_time: str, top_stats: dict, skill_data: dict, 
 	)
 
 #Add Glicko Leaderboard Support
-def update_glicko_ratings():
+def update_glicko_ratings(db_path: str = "Top_Stats.db"):
 
 	def create_table(cursor):
 		cursor.execute(
@@ -4097,8 +4097,8 @@ def update_glicko_ratings():
 		player_i.rating = min(max(player_i.getRating(), 100), 3000)
 
 
-	smaller_is_better_stats = {"damage_taken", "downed", "deaths"} 
-	conn = sqlite3.connect("Top_Stats.db")
+	smaller_is_better_stats = {"damage_taken", "downed", "deaths"}
+	conn = sqlite3.connect(db_path)
 	cursor = conn.cursor()
 
 	create_table(cursor)
@@ -4191,8 +4191,8 @@ def update_glicko_ratings():
 	print("Glicko ratings (with normalization and trends) updated.")
 
 
-def generate_leaderboard(stat: str, top_n: int = 25) -> str:
-	conn = sqlite3.connect('Top_Stats.db')
+def generate_leaderboard(stat: str, db_path: str, top_n: int = 25) -> str:
+	conn = sqlite3.connect(db_path)
 	cursor = conn.cursor()
 
 	cursor.execute('''
@@ -4496,9 +4496,9 @@ def build_high_scores_leaderboard_menu_tid(datetime: str, categories: list, tid_
 	)
 	
 
-def build_leaderboard_tids(tid_date_time: str, leaderboard_stats: dict, tid_list: list) -> None:
+def build_leaderboard_tids(tid_date_time: str, leaderboard_stats: dict, tid_list: list, db_path: str) -> None:
 	for stat in leaderboard_stats:
-		table = generate_leaderboard(stat)
+		table = generate_leaderboard(stat, db_path)
 		tid_title = f"{tid_date_time}-{stat}-Leaderboard"
 		tid_caption = f"🏆 {leaderboard_stats[stat]}"
 		tid_tags = tid_date_time
@@ -4531,7 +4531,7 @@ def build_leaderboard_menu_tid(datetime: str, leaderboard_stats: dict, tid_list:
 		tid_list
 	)
 
-def write_data_to_db(top_stats: dict, last_fight: str) -> None:
+def write_data_to_db(top_stats: dict, last_fight: str, db_path: str = "Top_Stats.db") -> None:
 		
 	"""
 	Write the top_stats dictionary to the database.
@@ -4546,7 +4546,7 @@ def write_data_to_db(top_stats: dict, last_fight: str) -> None:
 
 	print("Writing raid stats to database")
 	"""Write the top_stats dictionary to the database."""
-	conn = sqlite3.connect('Top_Stats.db')
+	conn = sqlite3.connect(db_path)
 	cursor = conn.cursor()
 
 	cursor.execute('''CREATE TABLE IF NOT EXISTS player_stats (

--- a/top_stats_config.ini
+++ b/top_stats_config.ini
@@ -11,8 +11,10 @@ input_directory = c:/gw2logs/output
 output_filename = None
 # json_output_filename overrides the default json filename
 json_output_filename = None
-# json_output_filename overrides the default dbname
-db_output_filename = TopStats.db
+# db_output_filename overrides the default database filename
+db_output_filename = Top_Stats.db
+# db_path specifies the directory where the database file is stored
+db_path = .
 # write_all_data_to_json toggle writing all accumulated data
 write_all_data_to_json = true
 #db_update toggle writing to the database

--- a/tw5_top_stats.py
+++ b/tw5_top_stats.py
@@ -18,6 +18,7 @@
 import argparse
 import configparser
 import sys
+import os
 import os.path
 from os import listdir
 import datetime
@@ -112,6 +113,11 @@ if __name__ == '__main__':
 	db_update = config_ini.getboolean('TopStatsCfg', 'db_update', fallback=False)
 	write_all_data_to_json = config_ini.getboolean('TopStatsCfg', 'write_all_data_to_json', fallback=False)
 	fight_data_charts = config_ini.getboolean('TopStatsCfg', 'fight_data_charts', fallback=False)
+	db_output_filename = config_ini.get('TopStatsCfg', 'db_output_filename', fallback='Top_Stats.db')
+	db_path = config_ini.get('TopStatsCfg', 'db_path', fallback='.')
+	if not os.path.isdir(db_path):
+		os.makedirs(db_path, exist_ok=True)
+	db_output_full_path = os.path.join(db_path, db_output_filename)
 
 	if args.output_filename is None:
 		args.output_filename = f"{input_directory}/Drag_and_Drop_Log_Summary_for_{tid_date_time}.json"
@@ -356,16 +362,16 @@ if __name__ == '__main__':
 		output_top_stats_json(top_stats, buff_data, skill_data, damage_mod_data, high_scores, personal_damage_mod_data, personal_buff_data, fb_pages, mechanics, minions, mesmer_clone_usage, death_on_tag, DPSStats, commander_summary_data, enemy_avg_damage_per_skill, player_damage_mitigation, player_minion_damage_mitigation, stacking_uptime_Table, IOL_revive, fight_data, args.json_output_filename)
 
 	if db_update:
-		write_data_to_db(top_stats, top_stats['overall']['last_fight'])
+		write_data_to_db(top_stats, top_stats['overall']['last_fight'], db_output_full_path)
 
-		update_glicko_ratings()
+		update_glicko_ratings(db_output_full_path)
 
 		leaderboard_stats = config_output.leaderboard_stats
-		build_leaderboard_tids(tid_date_time, leaderboard_stats , tid_list)
+		build_leaderboard_tids(tid_date_time, leaderboard_stats , tid_list, db_output_full_path)
 		build_leaderboard_menu_tid(tid_date_time, leaderboard_stats, tid_list)
 
-		write_high_scores_to_db(high_scores, top_stats['fight'], skill_data, "Top_Stats.db")
-		build_high_scores_leaderboard_tids(tid_date_time, "Top_Stats.db")
+		write_high_scores_to_db(high_scores, top_stats['fight'], skill_data, db_output_full_path)
+		build_high_scores_leaderboard_tids(tid_date_time, db_output_full_path)
 
 	write_tid_list_to_json(tid_list, args.output_filename)
 


### PR DESCRIPTION
As part of TopStatsAIO it would be very helpful to specify a database path as well as name. this is due to the transient nature of how TopStatsAIO handles pulling specific files and parsing.

This change should allow for a new `db_path` setting, allowing me to keep a persistent DB instance outside of where log combiner gets run. The alternative is to do some lift and shift of the `.db` file per run which is proving complex. 

**Where I need help** I can't fully test this as I don't know the method of compiling to an exe. My suggested testing paths:
- [x] Validate that the default value for `db_path` has no impact on base functionality
- [x] Validate that setting the `db_path` to something other than the root directory allows for a `.db` file to be read/written from/to.