### PR TITLE
Optional single-file compressed .html report (-b/--bake_html)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Currently works with WVW and Detailed WVW logs. Partially working with PVElogs, 
       - `python tw5_top_stats.py -c flux_config.ini`  # `-c` flag to utilize a specific `guild_config.ini` file
 
  - You can use [TopStatsAIO](https://github.com/darkharasho/TopStatsAIO) for a GUI frontend that utilizes Elite Insights CLI version and either of my parsers.
+ - You can bake a single shareable `.html` report directly (skips the drag and drop step) with the `-b` flag pointed at an empty viewer:
+   - `python tw5_top_stats.py -i d:\path\to\logs -b Example_Output\Top_Stats_Index.html`
+   - The baked report is written next to the summary `.json` and is compressed to roughly a quarter of the normal size (a ~10 MB night becomes ~3 MB, small enough to attach on Discord without zipping). It unpacks itself in the browser — needs a 2023-or-newer browser (Chrome/Edge 80+, Firefox 113+, Safari 16.4+).
+   - Set `bake_html_compress = False` under `[TopStatsCfg]` to bake uncompressed, or `bake_html_template = path\to\Top_Stats_Index.html` to enable baking from the config instead of the flag.
 
 ### Example Output of current state shown here:  [Log Summary](https://wvwlogs.com)
 

--- a/standalone_report.py
+++ b/standalone_report.py
@@ -1,0 +1,123 @@
+#    This file bakes the combined summary into a single shareable .html
+#    report file, optionally compressed to roughly a quarter of its size.
+#    Copyright (C) 2026 SimpleHonors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import base64
+import gzip
+import html
+import json
+import re
+
+TIDDLER_STORE_OPENER = '<script class="tiddlywiki-tiddler-store" type="application/json">'
+
+# Small loader page: carries the full report as base64(gzip(html)) and
+# unpacks it with the browser-native DecompressionStream (Chrome/Edge 80+,
+# Firefox 113+, Safari 16.4+). No external scripts, works offline and as a
+# Discord attachment. The unpacked document is byte-identical to the
+# uncompressed bake, so nothing about the report changes.
+LOADER_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; background: #1a1a2e; color: #ddd;
+         display: flex; align-items: center; justify-content: center;
+         height: 100vh; margin: 0; }}
+  .msg {{ text-align: center; }}
+  .err {{ color: #ff8080; max-width: 34em; }}
+</style>
+</head>
+<body>
+<div class="msg" id="m">Unpacking report&hellip;</div>
+<script id="z" type="text/plain">{payload}</script>
+<script>
+(async function () {{
+  var m = document.getElementById('m');
+  try {{
+    if (typeof DecompressionStream === 'undefined') {{
+      throw new Error('This report needs a current browser (Chrome, Edge, Firefox or Safari from 2023 or newer).');
+    }}
+    var b64 = document.getElementById('z').textContent;
+    var bin = atob(b64);
+    var bytes = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    var stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream('gzip'));
+    var doc = await new Response(stream).text();
+    document.open();
+    document.write(doc);
+    document.close();
+  }} catch (e) {{
+    m.className = 'msg err';
+    m.textContent = 'Could not open the report: ' + e.message;
+  }}
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+def inject_tid_list(template_html: str, tid_list: list) -> str:
+	"""Return the template with tid_list appended as a new tiddler store block.
+
+	Equivalent to drag-and-dropping the summary .json onto the template and
+	saving, but automatic. Raises ValueError if the template is not a
+	TiddlyWiki store-format html file.
+	"""
+	first = template_html.find(TIDDLER_STORE_OPENER)
+	if first == -1:
+		raise ValueError("template is not a TiddlyWiki store-format html file")
+	serialized = json.dumps(tid_list, ensure_ascii=False, separators=(",", ":"))
+	# "<" must not appear raw inside a script element (</script> would end it)
+	safe = serialized.replace("<", "\\u003C")
+	new_block = f"{TIDDLER_STORE_OPENER}{safe}</script>"
+	last_start = template_html.rfind(TIDDLER_STORE_OPENER)
+	close = template_html.index("</script>", last_start) + len("</script>")
+	return template_html[:close] + new_block + template_html[close:]
+
+
+def compress_html(full_html: str) -> str:
+	"""Wrap a report page in the self-unpacking loader (about 4x smaller)."""
+	m = re.search(r"<title>(.*?)</title>", full_html, re.DOTALL | re.IGNORECASE)
+	title = m.group(1).strip() if m else "Log Summary Report"
+	payload = base64.b64encode(gzip.compress(full_html.encode("utf-8"), 9)).decode("ascii")
+	return LOADER_TEMPLATE.format(title=html.escape(title), payload=payload)
+
+
+def decompress_html(packed_html: str) -> str:
+	"""Inverse of compress_html, for tooling and tests."""
+	m = re.search(r'<script id="z" type="text/plain">([A-Za-z0-9+/=]+)</script>', packed_html)
+	if not m:
+		raise ValueError("not a compressed report file")
+	return gzip.decompress(base64.b64decode(m.group(1))).decode("utf-8")
+
+
+def bake_standalone_html(template_path: str, tid_list: list, output_filename: str,
+						 compress: bool = True) -> str:
+	"""Bake tid_list into a single shareable .html report file.
+
+	template_path: an empty TW5 viewer such as Example_Output/Top_Stats_Index.html.
+	Returns output_filename.
+	"""
+	with open(template_path, encoding="utf-8") as f:
+		template_html = f.read()
+	full_html = inject_tid_list(template_html, tid_list)
+	if compress:
+		full_html = compress_html(full_html)
+	with open(output_filename, "w", encoding="utf-8") as f:
+		f.write(full_html)
+	return output_filename

--- a/tw5_top_stats.py
+++ b/tw5_top_stats.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
 	parser.add_argument('-j', '--json_output', dest="json_output_filename", help="Override .json file to write the computed stats data")
 	parser.add_argument('-c', '--config_file', dest="config_file", help="Select a specific config file. Defaults to top_stats_config.ini")
 	parser.add_argument('-d', '--description_append', dest="description_append", help="Appended to the description of the summary caption.")
+	parser.add_argument('-b', '--bake_html', dest="bake_html_template", help="Also bake a single shareable .html report using the given empty Top_Stats_Index.html as template (no drag and drop needed). Compressed to roughly a quarter of the size by default; see bake_html_compress in the config.")
 
 	args = parser.parse_args()
 
@@ -457,6 +458,18 @@ if __name__ == '__main__':
 		build_high_scores_leaderboard_tids(tid_date_time, db_output_full_path)
 
 	write_tid_list_to_json(tid_list, args.output_filename)
+
+	# Optional: bake a single shareable .html report (no drag and drop)
+	bake_html_template = args.bake_html_template or config_ini.get('TopStatsCfg', 'bake_html_template', fallback=None)
+	if bake_html_template:
+		from standalone_report import bake_standalone_html
+		bake_html_compress = config_ini.getboolean('TopStatsCfg', 'bake_html_compress', fallback=True)
+		baked_filename = os.path.splitext(args.output_filename)[0] + ".html"
+		try:
+			bake_standalone_html(bake_html_template, tid_list, baked_filename, compress=bake_html_compress)
+			print(f"Baked standalone report: {baked_filename} ({os.path.getsize(baked_filename):,} bytes)")
+		except (OSError, ValueError) as e:
+			print(f"Could not bake standalone report: {e}")
 
 	if team_code_missing:
 		print("Missing team codes: " + str(team_code_missing))


### PR DESCRIPTION
Hi! Thanks for the parser — our guild uses it every raid night (via TopStatsAIO and our own tooling) and it's been rock solid.

One pain point we kept hitting: the finished report for a full night is huge. A 34-fight night bakes to ~8.7 MB, which is past Discord's comfortable attachment sizes, so people end up zipping it — and then everyone has to unzip before they can look at it (and Discord likes to warn about zip files).

This PR adds an **opt-in** way to have the combiner produce a finished, shareable .html in one step:

- `-b`/`--bake_html <path to empty Top_Stats_Index.html>` bakes the summary tiddlers into the template automatically — same result as drag-and-drop + import + save, just no manual steps.
- By default the baked file is wrapped as base64(gzip) inside a tiny loader page that unpacks itself using the browser's built-in `DecompressionStream` — no external scripts, works offline and as a Discord attachment. Our 8.7 MB night became 2.96 MB.
- The unpacked document is byte-identical to the uncompressed bake (there's a `decompress_html` helper that we round-trip-test with), so the report itself is completely unchanged.
- `bake_html_compress = False` under `[TopStatsCfg]` bakes uncompressed; `bake_html_template` enables baking from the config instead of the flag.
- **Nothing changes for anyone who doesn't pass the flag** — the normal json output and workflow are untouched.

Caveat worth knowing: compressed reports need a 2023-or-newer browser (Chrome/Edge 80+, Firefox 113+, Safari 16.4+). Older browsers get a plain-English message instead of a broken page. Also note a baked single-file report can't be drag-and-drop *imported* into another wiki the way the .json can — the .json remains the import format; this is purely a share/view artifact.

Tested against a real 34-fight WvW night: byte-identical round-trip, and the compressed file renders identically (verified in Chromium, including navigating into the summary and the stat tables).

Licensed GPLv3 like the rest of the project. Happy to adjust naming, flag spelling, defaults — whatever fits your conventions best.