### PR TITLE
Add optional compressed standalone HTML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Currently works with WVW and Detailed WVW logs. Partially working with PVElogs, 
       - `python tw5_top_stats.py -c flux_config.ini`  # `-c` flag to utilize a specific `guild_config.ini` file
 
  - You can use [TopStatsAIO](https://github.com/darkharasho/TopStatsAIO) for a GUI frontend that utilizes Elite Insights CLI version and either of my parsers.
+ - You can create a single shareable standalone HTML report directly (skips the drag and drop step) with `--standalone-html` (`-s`) pointed at an empty viewer:
+   - `python tw5_top_stats.py -i d:\path\to\logs --standalone-html Example_Output\Top_Stats_Index.html`
+   - The report is written next to the summary `.json` and is typically much smaller than uncompressed HTML (observed savings vary with report content). It decompresses itself in the browser and requires `DecompressionStream` support (Chrome/Edge 80+, Firefox 113+, Safari 17+).
+   - Set `compress_standalone_html = false` under `[TopStatsCfg]` for ordinary uncompressed HTML, or set `standalone_html_template = path\to\Top_Stats_Index.html` to create the report from the config instead of the command-line option.
 
 ### Example Output of current state shown here:  [Log Summary](https://wvwlogs.com)
 

--- a/standalone_report.py
+++ b/standalone_report.py
@@ -1,0 +1,203 @@
+#    This file creates a standalone HTML report from the combined summary,
+#    optionally compressed for easier sharing.
+#    Copyright (C) 2026 SimpleHonors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import base64
+import binascii
+import gzip
+import html
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+TIDDLER_STORE_OPENER = '<script class="tiddlywiki-tiddler-store" type="application/json">'
+SCRIPT_CLOSER = "</script>"
+
+# Self-decompressing wrapper for a gzip-compressed standalone report.
+# The payload uses only browser-native APIs and has no external dependencies.
+LOADER_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{title}</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; background: #1a1a2e; color: #ddd;
+         display: flex; align-items: center; justify-content: center;
+         height: 100vh; margin: 0; }}
+  .msg {{ text-align: center; }}
+  .err {{ color: #ff8080; max-width: 34em; }}
+</style>
+</head>
+<body>
+<div class="msg" id="m">Unpacking report&hellip;</div>
+<script id="z" type="text/plain">{payload}</script>
+<script>
+(async function () {{
+  var m = document.getElementById('m');
+  try {{
+    if (typeof DecompressionStream === 'undefined') {{
+      throw new Error('This report needs a browser with DecompressionStream support.');
+    }}
+    var b64 = document.getElementById('z').textContent;
+    var bin = atob(b64);
+    b64 = null;
+    var bytes = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    bin = null;
+    var blob = new Blob([bytes]);
+    bytes = null;
+    var stream = blob.stream().pipeThrough(new DecompressionStream('gzip'));
+    blob = null;
+    var doc = await new Response(stream).text();
+    document.open();
+    document.write(doc);
+    document.close();
+  }} catch (e) {{
+    m.className = 'msg err';
+    m.textContent = 'Could not open the report: ' + e.message;
+  }}
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+def embed_tiddlers(template_html: str, tiddlers: list[dict[str, Any]]) -> str:
+	"""Return the template with tiddlers appended as a new tiddler store block.
+
+	Equivalent to drag-and-dropping the summary .json onto the template and
+	saving, but automatic. Raises ValueError if the template is not a
+	TiddlyWiki store-format html file.
+	"""
+	if not isinstance(template_html, str):
+		raise TypeError("template_html must be a string")
+	if not isinstance(tiddlers, list) or any(not isinstance(tiddler, dict) for tiddler in tiddlers):
+		raise TypeError("tiddlers must be a list of dictionaries")
+
+	last_start = template_html.rfind(TIDDLER_STORE_OPENER)
+	if last_start == -1:
+		raise ValueError("template is not a TiddlyWiki store-format html file")
+	close = template_html.find(SCRIPT_CLOSER, last_start)
+	if close == -1:
+		raise ValueError("template contains an unterminated TiddlyWiki store block")
+
+	serialized = json.dumps(tiddlers, ensure_ascii=False, separators=(",", ":"))
+	# "<" must not appear raw inside a script element (</script> would end it)
+	safe = serialized.replace("<", "\\u003C")
+	new_block = f"\n{TIDDLER_STORE_OPENER}{safe}{SCRIPT_CLOSER}"
+	close += len(SCRIPT_CLOSER)
+	# TiddlyWiki reads store blocks in document order. Appending generated
+	# tiddlers last makes them override same-titled template tiddlers, matching
+	# drag-and-drop import behavior.
+	return template_html[:close] + new_block + template_html[close:]
+
+
+def compress_standalone_html(full_html: str) -> str:
+	"""Wrap a standalone HTML report in a self-decompressing loader."""
+	if not isinstance(full_html, str):
+		raise TypeError("full_html must be a string")
+	m = re.search(r"<title>(.*?)</title>", full_html, re.DOTALL | re.IGNORECASE)
+	title = html.unescape(m.group(1).strip()) if m else "Log Summary Report"
+	payload = base64.b64encode(
+		gzip.compress(full_html.encode("utf-8"), compresslevel=9, mtime=0)
+	).decode("ascii")
+	return LOADER_TEMPLATE.format(title=html.escape(title), payload=payload)
+
+
+def decompress_standalone_html(packed_html: str) -> str:
+	"""Inverse of compress_standalone_html, for tooling and tests."""
+	if not isinstance(packed_html, str):
+		raise TypeError("packed_html must be a string")
+	m = re.search(r'<script id="z" type="text/plain">([A-Za-z0-9+/=]+)</script>', packed_html)
+	if not m:
+		raise ValueError("not a compressed report file")
+	try:
+		compressed = base64.b64decode(m.group(1), validate=True)
+		return gzip.decompress(compressed).decode("utf-8")
+	except (binascii.Error, gzip.BadGzipFile, UnicodeDecodeError, EOFError) as exc:
+		raise ValueError("compressed report payload is invalid") from exc
+
+
+def derive_standalone_filename(summary_filename: str) -> str:
+	"""Derive an HTML filename that cannot overwrite the summary JSON."""
+	root, extension = os.path.splitext(summary_filename)
+	if extension.lower() == ".html":
+		return root + ".standalone.html"
+	return root + ".html"
+
+
+def paths_refer_to_same_file(first_path: str, second_path: str) -> bool:
+	"""Return whether two paths resolve to the same existing or future file."""
+	first = Path(first_path).resolve()
+	second = Path(second_path).resolve()
+	if os.path.normcase(str(first)) == os.path.normcase(str(second)):
+		return True
+	return first.exists() and second.exists() and os.path.samefile(first, second)
+
+
+def create_standalone_html(template_path: str, tiddlers: list[dict[str, Any]], output_filename: str,
+						   compress: bool = True) -> str:
+	"""Create a standalone HTML report containing the supplied tiddlers.
+
+	template_path: an empty TW5 viewer such as Example_Output/Top_Stats_Index.html.
+	Returns output_filename.
+	"""
+	template = Path(template_path).resolve()
+	output = Path(output_filename).resolve()
+	if paths_refer_to_same_file(str(template), str(output)):
+		raise ValueError("template and output paths must refer to different files")
+
+	with template.open(encoding="utf-8") as f:
+		template_html = f.read()
+	full_html = embed_tiddlers(template_html, tiddlers)
+	if compress:
+		full_html = compress_standalone_html(full_html)
+
+	output_parent = output.parent
+	output_parent.mkdir(parents=True, exist_ok=True)
+	temp_name = None
+	try:
+		with tempfile.NamedTemporaryFile(
+			"w",
+			encoding="utf-8",
+			dir=output_parent,
+			prefix=f".{output.name}.",
+			suffix=".tmp",
+			delete=False,
+		) as temp_file:
+			temp_name = temp_file.name
+			temp_file.write(full_html)
+			temp_file.flush()
+			os.fsync(temp_file.fileno())
+		os.replace(temp_name, output)
+	except Exception:
+		if temp_name:
+			try:
+				os.unlink(temp_name)
+			except FileNotFoundError:
+				pass
+			except OSError as cleanup_error:
+				print(
+					f"Warning: could not remove temporary report {temp_name}: {cleanup_error}",
+					file=sys.stderr,
+				)
+		raise
+	return str(output_filename)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for GW2 EI log combiner."""

--- a/tests/test_standalone_report.py
+++ b/tests/test_standalone_report.py
@@ -1,0 +1,227 @@
+import base64
+import gzip
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from standalone_report import (
+	TIDDLER_STORE_OPENER,
+	compress_standalone_html,
+	create_standalone_html,
+	decompress_standalone_html,
+	derive_standalone_filename,
+	embed_tiddlers,
+	paths_refer_to_same_file,
+)
+
+
+MINIMAL_TEMPLATE = (
+	"<!doctype html><html><head><title>A &amp; B</title></head><body>"
+	f"{TIDDLER_STORE_OPENER}[]</script>"
+	"<script>window.booted = true;</script></body></html>"
+)
+
+
+class EmbedTiddlersTests(unittest.TestCase):
+	def test_appends_json_store_before_boot_scripts(self):
+		tiddlers = [{"title": "Report", "text": "contents"}]
+
+		result = embed_tiddlers(MINIMAL_TEMPLATE, tiddlers)
+
+		self.assertEqual(result.count(TIDDLER_STORE_OPENER), 2)
+		self.assertLess(result.index('"title":"Report"'), result.index("window.booted"))
+
+	def test_escapes_script_closer_in_tiddler_content(self):
+		result = embed_tiddlers(
+			MINIMAL_TEMPLATE,
+			[{"title": "Report", "text": "</script><script>alert(1)</script>"}],
+		)
+
+		appended_store = result.rsplit(TIDDLER_STORE_OPENER, 1)[1].split("</script>", 1)[0]
+		self.assertNotIn("<", appended_store)
+		self.assertIn("\\u003C/script>", appended_store)
+		self.assertEqual(
+			json.loads(appended_store)[0]["text"],
+			"</script><script>alert(1)</script>",
+		)
+
+	def test_generated_tiddlers_are_appended_after_template_tiddlers(self):
+		result = embed_tiddlers(
+			MINIMAL_TEMPLATE,
+			[{"title": "$:/SiteTitle", "text": "Generated title"}],
+		)
+
+		first_store = result.find(TIDDLER_STORE_OPENER)
+		generated_store = result.rfind(TIDDLER_STORE_OPENER)
+		self.assertGreater(generated_store, first_store)
+		self.assertLess(generated_store, result.index("window.booted"))
+
+	def test_rejects_non_tiddlywiki_template(self):
+		with self.assertRaisesRegex(ValueError, "not a TiddlyWiki"):
+			embed_tiddlers("<html></html>", [])
+
+	def test_rejects_unterminated_store(self):
+		with self.assertRaisesRegex(ValueError, "unterminated"):
+			embed_tiddlers(TIDDLER_STORE_OPENER + "[]", [])
+
+	def test_rejects_invalid_tiddler_collection(self):
+		for invalid in (None, {}, ["not a tiddler"]):
+			with self.subTest(invalid=invalid):
+				with self.assertRaises(TypeError):
+					embed_tiddlers(MINIMAL_TEMPLATE, invalid)
+
+
+class CompressionTests(unittest.TestCase):
+	def test_round_trip_preserves_unicode_exactly(self):
+		report = "<!doctype html><title>Raid 😀</title><p>αβγ</p>"
+		self.assertEqual(decompress_standalone_html(compress_standalone_html(report)), report)
+
+	def test_title_entities_are_escaped_exactly_once(self):
+		packed = compress_standalone_html(
+			"<html><head><title>Guild &amp; Raid</title></head></html>"
+		)
+		self.assertIn("<title>Guild &amp; Raid</title>", packed)
+		self.assertNotIn("&amp;amp;", packed)
+
+	def test_round_trip_preserves_script_like_tiddler_content(self):
+		tiddlers = [{
+			"title": "Special content",
+			"text": "</script><script>alert(1)</script> \u003C 😀",
+		}]
+		full_html = embed_tiddlers(MINIMAL_TEMPLATE, tiddlers)
+		unpacked = decompress_standalone_html(compress_standalone_html(full_html))
+		appended_store = unpacked.rsplit(TIDDLER_STORE_OPENER, 1)[1].split(
+			"</script>", 1
+		)[0]
+		self.assertEqual(json.loads(appended_store), tiddlers)
+
+	def test_compression_is_reproducible(self):
+		report = "<!doctype html><title>Raid</title>" + ("stats" * 1000)
+		first = compress_standalone_html(report)
+		second = compress_standalone_html(report)
+		self.assertEqual(first, second)
+		payload = first.split('<script id="z" type="text/plain">', 1)[1].split(
+			"</script>", 1
+		)[0]
+		# Gzip header bytes 4-7 are MTIME. Zero keeps identical inputs reproducible.
+		self.assertEqual(base64.b64decode(payload)[4:8], b"\0\0\0\0")
+
+	def test_rejects_invalid_payload(self):
+		payload = base64.b64encode(b"not gzip").decode("ascii")
+		packed = f'<script id="z" type="text/plain">{payload}</script>'
+		with self.assertRaisesRegex(ValueError, "payload is invalid"):
+			decompress_standalone_html(packed)
+
+	def test_loader_payload_is_gzip(self):
+		packed = compress_standalone_html("<title>Report</title>")
+		payload = packed.split('<script id="z" type="text/plain">', 1)[1].split(
+			"</script>", 1
+		)[0]
+		self.assertEqual(gzip.decompress(base64.b64decode(payload)), b"<title>Report</title>")
+
+
+class CreateStandaloneHtmlTests(unittest.TestCase):
+	def test_writes_uncompressed_report(self):
+		with tempfile.TemporaryDirectory() as directory:
+			template = Path(directory) / "template.html"
+			output = Path(directory) / "nested" / "report.html"
+			template.write_text(MINIMAL_TEMPLATE, encoding="utf-8")
+
+			returned = create_standalone_html(
+				str(template),
+				[{"title": "Report", "text": "contents"}],
+				str(output),
+				compress=False,
+			)
+
+			self.assertEqual(returned, str(output))
+			self.assertIn('"title":"Report"', output.read_text(encoding="utf-8"))
+			self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
+
+	def test_rejects_template_output_alias_without_changing_template(self):
+		with tempfile.TemporaryDirectory() as directory:
+			template = Path(directory) / "template.html"
+			template.write_text(MINIMAL_TEMPLATE, encoding="utf-8")
+
+			with self.assertRaisesRegex(ValueError, "different files"):
+				create_standalone_html(str(template), [], str(template))
+
+			self.assertEqual(template.read_text(encoding="utf-8"), MINIMAL_TEMPLATE)
+
+	def test_writes_compressed_report(self):
+		with tempfile.TemporaryDirectory() as directory:
+			template = Path(directory) / "template.html"
+			output = Path(directory) / "report.html"
+			template.write_text(MINIMAL_TEMPLATE, encoding="utf-8")
+
+			create_standalone_html(
+				str(template),
+				[{"title": "Report", "text": "contents"}],
+				str(output),
+			)
+
+			unpacked = decompress_standalone_html(output.read_text(encoding="utf-8"))
+			self.assertIn('"title":"Report"', unpacked)
+
+	def test_failed_replace_preserves_existing_report_and_removes_temporary_file(self):
+		with tempfile.TemporaryDirectory() as directory:
+			template = Path(directory) / "template.html"
+			output = Path(directory) / "report.html"
+			template.write_text(MINIMAL_TEMPLATE, encoding="utf-8")
+			output.write_text("existing report", encoding="utf-8")
+
+			with patch("standalone_report.os.replace", side_effect=OSError("interrupted")):
+				with self.assertRaisesRegex(OSError, "interrupted"):
+					create_standalone_html(str(template), [], str(output))
+
+			self.assertEqual(output.read_text(encoding="utf-8"), "existing report")
+			self.assertEqual(list(output.parent.glob(f".{output.name}.*.tmp")), [])
+
+
+class DeriveStandaloneFilenameTests(unittest.TestCase):
+	def test_replaces_non_html_extension(self):
+		self.assertEqual(derive_standalone_filename("report.json"), "report.html")
+		self.assertEqual(derive_standalone_filename("report.custom"), "report.html")
+
+	def test_appends_extension_to_extensionless_name(self):
+		self.assertEqual(derive_standalone_filename("report"), "report.html")
+
+	def test_never_reuses_html_summary_filename(self):
+		self.assertEqual(
+			derive_standalone_filename("report.html"),
+			"report.standalone.html",
+		)
+		self.assertEqual(
+			derive_standalone_filename("report.HTML"),
+			"report.standalone.html",
+		)
+
+
+class PathsReferToSameFileTests(unittest.TestCase):
+	def test_detects_lexical_aliases_for_future_file(self):
+		with tempfile.TemporaryDirectory() as directory:
+			directory_path = Path(directory)
+			direct = directory_path / "viewer.html"
+			alias = directory_path / "nested" / ".." / "viewer.html"
+			self.assertTrue(paths_refer_to_same_file(str(direct), str(alias)))
+
+	def test_detects_hard_link_aliases(self):
+		with tempfile.TemporaryDirectory() as directory:
+			original = Path(directory) / "viewer.html"
+			hard_link = Path(directory) / "viewer-link.html"
+			original.write_text(MINIMAL_TEMPLATE, encoding="utf-8")
+			os.link(original, hard_link)
+			self.assertTrue(paths_refer_to_same_file(str(original), str(hard_link)))
+
+	def test_distinguishes_different_paths(self):
+		with tempfile.TemporaryDirectory() as directory:
+			first = Path(directory) / "first.html"
+			second = Path(directory) / "second.html"
+			self.assertFalse(paths_refer_to_same_file(str(first), str(second)))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/top_stats_config.ini
+++ b/top_stats_config.ini
@@ -7,6 +7,12 @@ guild_id = F359A3AE-0EA3-E811-81A9-CEE44FED0C20
 api_key = None
 # input_directory where the EI json logs are located
 input_directory = c:/gw2logs/output
+# Optional path to an empty Top_Stats_Index.html template. Leave blank to generate
+# only the normal drag-and-drop JSON, or pass -s/--standalone-html instead.
+standalone_html_template =
+# Compress standalone HTML reports for easier sharing. Requires a browser with
+# DecompressionStream support. Set false to produce ordinary uncompressed HTML.
+compress_standalone_html = true
 # output_filename overrides the standard output filename
 output_filename = None
 # json_output_filename overrides the default json filename

--- a/tw5_top_stats.py
+++ b/tw5_top_stats.py
@@ -64,6 +64,7 @@ if __name__ == '__main__':
 	parser.add_argument('-j', '--json_output', dest="json_output_filename", help="Override .json file to write the computed stats data")
 	parser.add_argument('-c', '--config_file', dest="config_file", help="Select a specific config file. Defaults to top_stats_config.ini")
 	parser.add_argument('-d', '--description_append', dest="description_append", help="Appended to the description of the summary caption.")
+	parser.add_argument('-s', '--standalone-html', dest="standalone_html_template", help="Create a standalone HTML report using the given empty Top_Stats_Index.html as the template. The report is compressed by default; see compress_standalone_html in the config.")
 
 	args = parser.parse_args()
 
@@ -75,6 +76,22 @@ if __name__ == '__main__':
 
 	config_ini = configparser.ConfigParser()
 	config_ini.read(args.config_file)
+
+	standalone_html_template = args.standalone_html_template or config_ini.get('TopStatsCfg', 'standalone_html_template', fallback=None)
+	compress_standalone = True
+	if standalone_html_template:
+		# Validate configuration before starting potentially expensive log parsing.
+		if not os.path.isfile(standalone_html_template):
+			parser.error(
+				f"standalone HTML template is not a file: {standalone_html_template}"
+			)
+		try:
+			compress_standalone = config_ini.getboolean('TopStatsCfg', 'compress_standalone_html', fallback=True)
+		except ValueError:
+			parser.error(
+				"compress_standalone_html in [TopStatsCfg] must be "
+				"true/false, yes/no, on/off, or 1/0"
+			)
 
 	# Resolve input_directory
 	input_directory = args.input_directory or config_ini.get('TopStatsCfg', 'input_directory', fallback='./')
@@ -128,6 +145,16 @@ if __name__ == '__main__':
 	else:
 		args.output_filename = os.path.join(input_directory, args.output_filename)
 
+	standalone_filename = None
+	if standalone_html_template:
+		from standalone_report import derive_standalone_filename, paths_refer_to_same_file
+		standalone_filename = derive_standalone_filename(args.output_filename)
+		if paths_refer_to_same_file(standalone_html_template, standalone_filename):
+			parser.error(
+				"standalone HTML template and output paths must refer to "
+				"different files"
+			)
+
 	# Config values
 	guild_name = config_ini.get('TopStatsCfg', 'guild_name', fallback=None)
 	guild_id = config_ini.get('TopStatsCfg', 'guild_id', fallback=None)
@@ -154,7 +181,7 @@ if __name__ == '__main__':
 	discord_additional_notes = config_ini.get('DiscordCfg', 'discord_additional_notes', fallback=None)
 
 	profession_color = config_output.profession_color
-	
+
 	LATEST_VERSION = check_for_update()
 
 	# Ensure output directories exist
@@ -458,6 +485,15 @@ if __name__ == '__main__':
 
 	write_tid_list_to_json(tid_list, args.output_filename)
 
+	if standalone_html_template:
+		from standalone_report import create_standalone_html
+		try:
+			create_standalone_html(standalone_html_template, tid_list, standalone_filename, compress=compress_standalone)
+			print(f"Created standalone HTML report: {standalone_filename} ({os.path.getsize(standalone_filename):,} bytes)")
+		except (OSError, ValueError) as e:
+			print(f"Error: could not create standalone HTML report: {e}", file=sys.stderr)
+			sys.exit(1)
+
 	if team_code_missing:
 		print("Missing team codes: " + str(team_code_missing))
 		print("Please review and add to config.py file")
@@ -481,5 +517,3 @@ if __name__ == '__main__':
 			print("No support professions found")
 		if not webhook_url:
 			print("No webhook URL found")
-
-	


### PR DESCRIPTION
Hi! Thanks for taking a look at the earlier version and testing it with a few raid nights.

After closing the original PR, I spent some more time reviewing the code and had a couple of additional reviews done. We found a few areas that needed shoring up, so this version includes those fixes along with better test coverage.

This adds an optional way to create a standalone HTML report without the usual drag-and-drop import step.

### What it does

- Adds `-s` / `--standalone-html` for selecting an empty `Top_Stats_Index.html` template.
- Embeds the generated Tiddlers into a standalone HTML report.
- Compresses the report by default to make it easier to share.
- Keeps the existing JSON output and workflow unchanged.
- Supports uncompressed output through `compress_standalone_html = false`.
- Allows the template to be configured with `standalone_html_template`.

### Changes made after the additional review

- Updated the naming to follow TiddlyWiki's standalone HTML terminology.
- Added validation for missing templates and conflicting output paths.
- Prevented the standalone report from overwriting the JSON summary.
- Improved error messages for invalid configuration and write failures.
- Made compressed output reproducible.
- Added safer temporary-file handling.
- Fixed HTML title escaping.
- Added coverage for Unicode, script-like content, path aliases, duplicate Tiddler titles, malformed input, and interrupted writes.

The final version has 22 passing tests. I also verified the compressed report against the included TiddlyWiki template in Chromium, including offline loading, Unicode content, duplicate-title behavior, and a clean browser console.

Compressed reports require browser support for `DecompressionStream`. The documented compatibility is Chrome and Edge 80+, Firefox 113+, and Safari 17+.

Nothing changes unless standalone HTML output is requested.

This should now be in much better shape than my first overly enthusiastic attempt. Thanks again for being open to the idea, and I am happy to adjust anything to better fit the project.
